### PR TITLE
Support bsd/posix invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,8 @@ endif
 all: make_dirs yacc pixelopolis
 
 make_dirs:
-	mkdir out -p
-	mkdir out/draw_builder/ -p
-	mkdir out/css_draw/ -p
-	mkdir tests_out -p
+	mkdir -p out/{draw_builder,css_draw}/
+	mkdir -p tests_out
 
 yacc: src/css.y src/css.l
 	$(YACC) src/css.y --defines=include/css.y.h --output=src/css.y.c -v

--- a/src/css.y
+++ b/src/css.y
@@ -491,7 +491,7 @@ args:
         | args COMMA sp obj { append_to_array($1, OBJS_SIZE, $4); $$ = $1; }
         ;
 
-sp: SPACE | sp SPACE | %empty;
+sp: SPACE | sp SPACE | /* empty */;
 %%
 
 struct Program* css_parse_file(char* filename) {


### PR DESCRIPTION
Changes:
1. The `mdkir <dir1> -p; mkdir <dir2> -p` invocations to `mkdir -p {<dir1>,<dir2>}` to support `mkdir` on MacOS

2. The `src/css.y` rule to remain POSIX compliant by using _empty_ comment instead of directive, see https://www.gnu.org/software/bison/manual/html_node/Empty-Rules.html